### PR TITLE
Fixed possible CPU intensive go routine leak from watcher.

### DIFF
--- a/grpc/naming.go
+++ b/grpc/naming.go
@@ -69,14 +69,14 @@ func (w *watcher) run() {
 	// First make sure that the initial read is an Add operation of the whole set.
 	w.next <- &updatesOrErr{updates: targetsToUpdate(w.existingTargets, naming.Add)}
 	erroredLoops := 0
-	for true {
+	for {
 		timeToSleep := targetsMinTtl(w.existingTargets)
 		select {
 		case <-w.close:
 			w.next <- &updatesOrErr{err: fmt.Errorf("closed watcher")}
 			close(w.next)
 			return
-		case <-time.Tick(timeToSleep):
+		case <-time.After(timeToSleep):
 		}
 		freshTargets, err := w.resolver.Lookup(w.domainName)
 		if err != nil {


### PR DESCRIPTION
While investigating CPU with pprof on our services that uses the mentioned watcher, we found that massive CPU usage was caused by `runtime.siftdownTimer`.
The source of this large amount of generated Tickers was this place `naming.go:79 time.Tick`

Moving that to time.After fixes the issue.
We cannot create Tick before loop and reuse that, since timeToSleep is dynamic.

See: https://forum.golangbridge.org/t/runtime-siftdowntimer-consuming-60-of-the-cpu/3773

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>